### PR TITLE
Removal of obsolete futurerestore download links and temporary correction to the latest build

### DIFF
--- a/downr1n.sh
+++ b/downr1n.sh
@@ -596,13 +596,15 @@ check_and_install_package "pyliblzfse"
 if [ ! -e "$dir"/futurerestore ]; then 
     printg "[*] Downloading futurerestore please wait..." # futurerestore downloader by sasa :)
     if [ "$os" = "Darwin" ]; then
-        curl -sLo futurerestore-macOS-RELEASE.zip https://nightly.link/futurerestore/futurerestore/workflows/ci/main/futurerestore-macOS-RELEASE.zip
-        unzip futurerestore-macOS-RELEASE.zip
-        tar Jxfv futurerestore-*.xz
+    # Expired link / artifact (Mac OS)
+    #    curl -sLo futurerestore-macOS-RELEASE.zip https://nightly.link/futurerestore/futurerestore/workflows/ci/main/futurerestore-macOS-RELEASE.zip
+    #    unzip futurerestore-macOS-RELEASE.zip
+    #    tar Jxfv futurerestore-*.xz
     else
-        curl -sLo futurerestore-Linux-x86_64-RELEASE.zip https://nightly.link/futurerestore/futurerestore/workflows/ci/main/futurerestore-Linux-x86_64-RELEASE.zip
-        unzip futurerestore-Linux-x86_64-RELEASE.zip
-        tar Jxfv futurerestore-*.xz
+    # Expired link / artifact (Linux)
+    #    curl -sLo futurerestore-Linux-x86_64-RELEASE.zip https://nightly.link/futurerestore/futurerestore/workflows/ci/main/futurerestore-Linux-x86_64-RELEASE.zip
+    #    unzip futurerestore-Linux-x86_64-RELEASE.zip
+    #    tar Jxfv futurerestore-*.xz
     fi
     mv futurerestore "$dir"/
     rm -rf futurerestore-*

--- a/downr1n.sh
+++ b/downr1n.sh
@@ -596,11 +596,28 @@ check_and_install_package "pyliblzfse"
 if [ ! -e "$dir"/futurerestore ]; then 
     printg "[*] Downloading futurerestore please wait..." # futurerestore downloader by sasa :)
     if [ "$os" = "Darwin" ]; then
+        # Retrieving the latest build : https://github.com/futurerestore/futurerestore/actions
+        # Last update : 2024-09-08 (https://nightly.link/futurerestore/futurerestore/actions/runs/10756811250)
+
+        # Temporary solution: please specify a version compatible with downra1n fuurerestore commands.
+        curl -sLo futurerestore-macOS-RELEASE.zip https://nightly.link/futurerestore/futurerestore/actions/runs/10756811250/futurerestore-macOS-RELEASE.zip
+        unzip futurerestore-macOS-RELEASE.zip
+        tar Jxfv futurerestore-*.xz
+    
     # Expired link / artifact (Mac OS)
     #    curl -sLo futurerestore-macOS-RELEASE.zip https://nightly.link/futurerestore/futurerestore/workflows/ci/main/futurerestore-macOS-RELEASE.zip
     #    unzip futurerestore-macOS-RELEASE.zip
     #    tar Jxfv futurerestore-*.xz
+
     else
+        # Retrieving the latest build : https://github.com/futurerestore/futurerestore/actions
+        # Last update : 2024-09-08 (https://nightly.link/futurerestore/futurerestore/actions/runs/10756811250)
+
+        # Temporary solution: please specify a version compatible with downra1n fuurerestore commands.
+        curl -sLo futurerestore-Linux-x86_64-RELEASE.zip https://nightly.link/futurerestore/futurerestore/actions/runs/10756811250/futurerestore-Linux-x86_64-RELEASE.zip
+        unzip futurerestore-Linux-x86_64-RELEASE.zip
+        tar Jxfv futurerestore-*.xz
+    
     # Expired link / artifact (Linux)
     #    curl -sLo futurerestore-Linux-x86_64-RELEASE.zip https://nightly.link/futurerestore/futurerestore/workflows/ci/main/futurerestore-Linux-x86_64-RELEASE.zip
     #    unzip futurerestore-Linux-x86_64-RELEASE.zip


### PR DESCRIPTION
While running downra1n I noticed that the futurestore download step was no longer working, so I corrected this step directly in the code.

- Modification from line 598 to line 625 for Mac Os and Linux version.